### PR TITLE
btc_p_redeploy_base do not exist anymore

### DIFF
--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/fob/redeploy.sqf
@@ -22,7 +22,7 @@ createDialog "btc_fob_redeploy";
 waitUntil {dialog};
 
 _idc = 778;
-if (btc_p_redeploy_base) then {lbAdd [ _idc, "Base"];};
+lbAdd [ _idc, "Base"];
 
 {_index = lbAdd [ _idc, _x ];} foreach _fobs;
 


### PR DESCRIPTION
btc_p_redeploy_base do not exist anymore in mission.sqf
This generate a bug in redeploy.sqf
You can't access to BASE spawn.
