### PR TITLE
Keep werck Helo during 10 minutes

### DIFF
--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/veh_track_marker.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/veh_track_marker.sqf
@@ -32,8 +32,14 @@ _marker setMarkerColor "ColorRed";
 if (_resp) then 
 {
 	sleep (_this select 2);
-	
-	deleteVehicle _veh;
+	if (200 > ((getPos _veh) distance _v_pos)) then 
+	{ 
+	deleteVehicle _veh; //remove werck if is too close to the initial spawn
+	} 
+	else 
+	{
+	_veh spawn {sleep 600;deleteVehicle _this;}; //keep werck
+	};
 
 	_veh = _v_type createVehicle _v_pos;
 	_veh setDir _v_dir;


### PR DESCRIPTION
When the Helo is destroyed, it respawn after 30 secondes but the werck stay during 10 minutes for more realism.
If the crash occure too close from the base, the werck is removed before respawn.
