### PR TITLE
FIX : randomize_pos.sqf don't return an array with the same size

### DIFF
--- a/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/common/randomize_pos.sqf
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/core/fnc/common/randomize_pos.sqf
@@ -11,10 +11,13 @@ _pos_y = _pos_y + ((random _random_area) - (random _random_area));
 
 _check_pos = [_pos_x, _pos_y, 0];
 
-if (surfaceIsWater _check_pos) then 
+if (surfaceIsWater _check_pos) then
 {
 	_return_pos = [_check_pos, 0, _random_area, 13, 0, 60 * (pi / 180), 0] call BIS_fnc_findSafePos;
-} 
+	_pos_x = _return_pos select 0;
+	_pos_y = _return_pos select 1;
+	_return_pos = [_pos_x, _pos_y, 0];
+}
 else
 {
 	_return_pos = _check_pos;


### PR DESCRIPTION
FIX randomize_pos.sqf : return  an array of three or two elements if
BIS_fnc_findSafePos is call or not.
Now it always return an array of three elements.

Hideout close to water doesn't spawn in the sky at Drima location.
