### PR TITLE
FIX : A3 mission editor remove name ="btc_curator";

### DIFF
--- a/=BTC=co@22_Hearts_and_Minds.Altis/mission.sqm
+++ b/=BTC=co@22_Hearts_and_Minds.Altis/mission.sqm
@@ -749,7 +749,7 @@ class Mission
 					id=26;
 					side="LOGIC";
 					vehicle="ModuleCurator_F";
-					name ="btc_curator";
+					text="btc_curator";
 					leader=1;
 					lock="UNLOCKED";
 					skill=0.60000002;


### PR DESCRIPTION
When you edit the mission with the 2D mission editor, the name
="btc_curator"; line is always removed in mission.sqm.

FIX : replace
name ="btc_curator";
by 
text ="btc_curator";
