### PR TITLE
DB FIX: objects loaded in cargo are missing after server restart

### DIFF
--- a/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_load.sqf
+++ b/=BTC=co@30_Hearts_and_Minds.Altis/core/fnc/log/server_load.sqf
@@ -1,4 +1,6 @@
 
+private ["_obj","_veh","_cargo"];
+
 _obj = _this select 0;
 _veh = _this select 1;
 


### PR DESCRIPTION
FIX : Multiple objects loaded in cargo are missing after server restart in container.
- load in container more than one object
- save mission
- restart server
- check cargo of container
- only one object has been saved in container cargo
